### PR TITLE
update path to color presets

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ Download using the [GitHub `.zip` download](https://github.com/dracula/iterm/arc
 
 #### Activating theme
 
-1.  _iTerm2 > Settings > Profiles > Colors Tab_;
+1.  _iTerm2 > Settings... > Profiles > Colors Tab_;
 2.  Open the _Color Presets..._ drop-down in the bottom right corner;
 3.  Select _Import..._ from the list;
 4.  Select the `Dracula.itermcolors` file;

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ Download using the [GitHub `.zip` download](https://github.com/dracula/iterm/arc
 
 #### Activating theme
 
-1.  _iTerm2 > Preferences > Profiles > Colors Tab_;
+1.  _iTerm2 > Settings > Profiles > Colors Tab_;
 2.  Open the _Color Presets..._ drop-down in the bottom right corner;
 3.  Select _Import..._ from the list;
 4.  Select the `Dracula.itermcolors` file;


### PR DESCRIPTION
The file path has been updated since iTerm2 no longer has a `preferences` drop down to get to the appropriate file path.

<img width="907" alt="Screenshot 2024-10-19 at 7 31 21 AM" src="https://github.com/user-attachments/assets/a6fba7ea-2e30-4679-96e1-c38d0a3a6b51">
